### PR TITLE
Remove # preprocessor syntax

### DIFF
--- a/syntaxes/gas.tmLanguage
+++ b/syntaxes/gas.tmLanguage
@@ -336,18 +336,6 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>^\s*(?&lt;!#)(#(#(?!#)|(un)?assert|define|elif|else|endif|error|ident|(ifn?|un)?def|if|import|include(_next)?|line|pragma|sccs|warning))|__(FILE|LINE|DATE|TIME(STAMP)?|STDC_(VERSION|HOSTED)?|GNUC|GNUC_MINOR|GNUC_PATCHLEVEL|VERSION|STRICT_ANSI|BASE_FILE|INCLUDE_LEVEL|OPTIMIZE|OPTIMIZE_SIZE|NO_INLINE|CHAR_UNSIGNED|CHAR_BIT|INT_SHORT|SCHAR_MAX|SHRT_MAX|INT_MAX|LONG_MAX|LONG_LONG_MAX|REGISTER_PREFIX|USER_LABEL_PREFIX)__\b</string>
-			<key>name</key>
-			<string>support.constant.preprocessor</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>^\s*(#\s+((un)?assert|define|elif|else|endif|error|ident|(ifn?|un)?def|if|import|include(_next)?|line|pragma|sccs|warning)\b).*</string>
-			<key>name</key>
-			<string>invalid.warnings</string>
-		</dict>
-		<dict>
-			<key>match</key>
 			<string>(#|//).*$</string>
 			<key>name</key>
 			<string>comment.assembly</string>


### PR DESCRIPTION
This fixes incorrect highlighting in comments starting with '#'.